### PR TITLE
Update book_info_view.py

### DIFF
--- a/src/view/info/book_info_view.py
+++ b/src/view/info/book_info_view.py
@@ -8,7 +8,7 @@ from PySide6.QtCore import Qt, QSize, QEvent, Signal
 from PySide6.QtGui import QColor, QFont, QPixmap, QIcon, QCursor
 from PySide6.QtWidgets import QListWidgetItem, QLabel, QApplication, QScroller, QPushButton, QButtonGroup, QMessageBox, \
     QListView, QWidget, QMenu
-from win32ctypes.pywin32.pywintypes import datetime
+from datetime import datetime
 
 from component.layout.flow_layout import FlowLayout
 from config.setting import Setting


### PR DESCRIPTION
Mac os does not support PyWin32. datetime does not need to be imported from pywin32 either.