### PR TITLE
feat: add XDG base directory support for Linux

### DIFF
--- a/src/config/setting.py
+++ b/src/config/setting.py
@@ -1,5 +1,8 @@
 import os
 import shutil
+import sys
+
+from config import config
 
 
 class SettingValue:
@@ -204,6 +207,8 @@ class Setting:
                 setItem.InitValue(value, name)
         from tools.log import Log
         Log.UpdateLoggingLevel()
+        if sys.platform == "linux" and not Setting.SavePath.value:
+            Setting.SavePath.SetValue(Setting.GetDataPath())
         return
 
     @staticmethod
@@ -227,29 +232,45 @@ class Setting:
 
     @staticmethod
     def Init():
-        path = Setting.GetConfigPath()
-        if not os.path.isdir(path):
-            os.mkdir(path)
+        for path in [
+            Setting.GetConfigPath(),
+            Setting.GetDataPath(),
+            Setting.GetCachePath(), 
+            Setting.GetStatePath(),
+        ]:
+            os.makedirs(path, exist_ok=True)
         return
 
     @staticmethod
-    def GetConfigPath():
-        import sys
+    def _xdgDir(envName, default, *subdirs):
         if sys.platform == "win32":
             return "data"
-        else:
-            from PySide6.QtCore import QDir
-            homePath = QDir.homePath()
-            projectName = ".picacg"
-            return os.path.join(homePath, projectName)
+        base = os.environ.get(envName, os.path.join(os.path.expanduser("~"), default))
+        return os.path.join(base, "picacg-qt", *subdirs)
+
+    @staticmethod
+    def GetConfigPath():
+        return Setting._xdgDir("XDG_CONFIG_HOME", ".config")
+
+    @staticmethod
+    def GetDataPath():
+        return Setting._xdgDir("XDG_DATA_HOME", ".local/share")
+
+    @staticmethod
+    def GetCachePath():
+        if sys.platform == "win32":
+            return os.path.join(Setting.SavePath.value, config.CachePathDir)
+        return Setting._xdgDir("XDG_CACHE_HOME", ".cache")
+
+    @staticmethod
+    def GetStatePath():
+        return Setting._xdgDir("XDG_STATE_HOME", ".local/state")
 
     @staticmethod
     def GetLogPath():
-        import sys
         if Setting.LogDirPath.value:
             return Setting.LogDirPath.value
 
         if sys.platform == "win32":
             return "logs"
-        else:
-            return os.path.join(Setting.GetConfigPath(), "logs")
+        return Setting._xdgDir("XDG_STATE_HOME", ".local/state", "logs")

--- a/src/config/setting.py
+++ b/src/config/setting.py
@@ -230,19 +230,7 @@ class Setting:
         path = Setting.GetConfigPath()
         if not os.path.isdir(path):
             os.mkdir(path)
-        path2 = Setting.GetLocalHomePath()
-        if not os.path.isdir(path2):
-            os.mkdir(path2)
-        Setting.CheckRepair()
-        Setting.CheckRepairLocalDb()
         return
-
-    @staticmethod
-    def GetLocalHomePath():
-        from PySide6.QtCore import QDir
-        homePath = QDir.homePath()
-        projectName = ".comic-qt"
-        return os.path.join(homePath, projectName)
 
     @staticmethod
     def GetConfigPath():
@@ -265,49 +253,3 @@ class Setting:
             return "logs"
         else:
             return os.path.join(Setting.GetConfigPath(), "logs")
-
-    @staticmethod
-    def CheckRepair():
-        import sys
-        if not sys.platform == "win32":
-            return
-        try:
-            from PySide6.QtCore import QDir
-            homePath = QDir.homePath()
-            projectName = ".picacg"
-            oldPath = os.path.join(homePath, projectName)
-            fileList = ["download.db", "config.ini", "history.db", "cache_word"]
-            for file in fileList:
-                filePath = os.path.join("data", file)
-                if not os.path.isfile(filePath):
-                    oldFilePath = os.path.join(oldPath, file)
-                    if os.path.isfile(oldFilePath):
-                        shutil.move(oldFilePath, filePath)
-                    elif os.path.isfile(file):
-                        shutil.move(file, filePath)
-
-        except Exception as es:
-            from tools.log import Log
-            Log.Error(es)
-
-    @staticmethod
-    def CheckRepairLocalDb():
-        try:
-            fileName = os.path.join(Setting.GetLocalHomePath(), "local_read.db")
-            toFileName = os.path.join(Setting.GetConfigPath(), "local_read.db")
-            from config import config
-            copyOkName = os.path.join(Setting.GetLocalHomePath(), "{}_local.ok".format(config.ProjectName))
-            from PySide6.QtCore import QDir
-            if os.path.isfile(copyOkName):
-                return
-            if not os.path.isfile(fileName):
-                return
-            if os.path.isfile(toFileName):
-                return
-            shutil.copy(fileName, copyOkName)
-            shutil.copy(fileName, toFileName)
-            from server import Log
-            Log.Warn("copy local read db")
-        except Exception as es:
-            from tools.log import Log
-            Log.Error(es)

--- a/src/server/sql_server.py
+++ b/src/server/sql_server.py
@@ -95,7 +95,7 @@ class SqlServer(Singleton):
         conn = None
         try:
             if sys.platform == "linux":
-                path = os.path.join(Setting.GetConfigPath(), bookPath)
+                path = os.path.join(Setting.GetDataPath(), bookPath)
                 conn = sqlite3.connect(path)
             else:
                 conn = sqlite3.connect(bookPath)

--- a/src/server/sql_server.py
+++ b/src/server/sql_server.py
@@ -614,7 +614,7 @@ class SqlServer(Singleton):
 
     @staticmethod
     def SaveCacheWord():
-        path = os.path.join(Setting.GetConfigPath(), "cache_word")
+        path = os.path.join(Setting.GetConfigPath() if sys.platform == "win32" else Setting.GetCachePath(), "cache_word")
         try:
             if not SqlServer().cacheWord:
                 return
@@ -626,7 +626,7 @@ class SqlServer(Singleton):
 
     @staticmethod
     def LoadCacheWord():
-        path = os.path.join(Setting.GetConfigPath(), "cache_word")
+        path = os.path.join(Setting.GetConfigPath() if sys.platform == "win32" else Setting.GetCachePath(), "cache_word")
         try:
             if not os.path.isfile(path):
                 return

--- a/src/task/qt_task.py
+++ b/src/task/qt_task.py
@@ -67,8 +67,7 @@ class QtTaskBase:
             # else:
             #     a = hashlib.md5(path.encode("utf-8")).hexdigest() + ".jpg"
             if Setting.SavePath.value and path:
-                filePath2 = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir), path)
-                cachePath = filePath2
+                cachePath = os.path.join(Setting.GetCachePath(), path)
         return TaskDownload().DownloadTask(url, path, downloadCallBack, completeCallBack, downloadStCallBack, backParam, loadPath, cachePath, savePath, cleanFlag, isReload, resetCnt)
 
     # downloadCallBack(data, laveFileSize, backParam)

--- a/src/task/task_download.py
+++ b/src/task/task_download.py
@@ -314,7 +314,7 @@ class TaskDownload(TaskBase, QtTaskBase):
                         return
                 else:
                     path = ToolUtil.GetRealPath(task.index+1, "book/{}/{}".format(task.bookId, task.epsId+1))
-                    cachePath2 = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir), path)
+                    cachePath2 = os.path.join(Setting.GetCachePath(), path)
                     checkPaths = [task.loadPath]
 
                     if Setting.SavePath.value:

--- a/src/task/task_waifu2x.py
+++ b/src/task/task_waifu2x.py
@@ -188,7 +188,7 @@ class TaskWaifu2x(TaskBase):
         info.preDownPath = preDownPath
         info.noSaveCache = noSaveCache
         if not noSaveCache and path and Setting.SavePath.value:
-            info.cachePath = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir), os.path.join("waifu2x", path))
+            info.cachePath = os.path.join(Setting.GetCachePath(), os.path.join("waifu2x", path))
 
         if cleanFlag:
             info.cleanFlag = cleanFlag

--- a/src/view/chat/chat_room_widget.py
+++ b/src/view/chat/chat_room_widget.py
@@ -266,7 +266,7 @@ class ChatRoomWidget(QWidget, Ui_ChatRoom, QtTaskBase):
                 byte = base64.b64decode(imageData[1])
                 date = time.strftime('%Y%m%d_%H%M%S', time.localtime(time.time()))
                 if Setting.SavePath.value:
-                    path = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir), "chat/picture/{}_{}.jpg".format(date, random.randint(1, 999)))
+                    path = os.path.join(Setting.GetCachePath(), "chat/picture/{}_{}.jpg".format(date, random.randint(1, 999)))
                     ToolUtil.SaveFile(byte, path)
                 info.SetPictureComment(byte)
 
@@ -279,7 +279,7 @@ class ChatRoomWidget(QWidget, Ui_ChatRoom, QtTaskBase):
                 saveName = str(int(time.time())) + "_" + str(random.randint(1, 1000)) + ".3gp"
                 info.toolButton.setText(saveName)
                 if Setting.SavePath.value:
-                    path = os.path.join(Setting.SavePath.value, config.ChatSavePath)
+                    path = os.path.join(Setting.GetCachePath(), config.ChatSavePath, "audio")
                     saveName = os.path.join(path, saveName)
                     info.audioData = saveName
                     if not os.path.isdir(path):

--- a/src/view/convert/convert_db.py
+++ b/src/view/convert/convert_db.py
@@ -13,7 +13,7 @@ from view.download.download_item import DownloadItem, DownloadEpsItem
 class ConvertDb(object):
     def __init__(self):
         self.db = QSqlDatabase.addDatabase("QSQLITE", "convert")
-        path = os.path.join(Setting.GetConfigPath(), "convert.db")
+        path = os.path.join(Setting.GetStatePath(), "convert.db")
         self.db.setDatabaseName(path)
         if not self.db.open():
             Log.Warn(self.db.lastError().text())

--- a/src/view/download/download_db.py
+++ b/src/view/download/download_db.py
@@ -12,7 +12,7 @@ from view.download.download_item import DownloadItem, DownloadEpsItem
 class DownloadDb(object):
     def __init__(self):
         self.db = QSqlDatabase.addDatabase("QSQLITE", "download")
-        path = os.path.join(Setting.GetConfigPath(), "download.db")
+        path = os.path.join(Setting.GetStatePath(), "download.db")
         self.db.setDatabaseName(path)
         if not self.db.open():
             Log.Warn(self.db.lastError().text())

--- a/src/view/download/download_dir_view.py
+++ b/src/view/download/download_dir_view.py
@@ -28,9 +28,9 @@ class DownloadDirView(BaseMaskDialog, Ui_DownloadDir, QtTaskBase):
         if url:
             self.lineEdit.setText(url)
             self.downloadDir.setText(os.path.join(url, config.SavePathDir))
-            self.chatDir.setText(os.path.join(url, config.ChatSavePath))
-            self.cacheDir.setText(os.path.join(url, config.CachePathDir))
-            self.waifu2xDir.setText(os.path.join(os.path.join(url, config.CachePathDir), config.Waifu2xPath))
+            self.chatDir.setText(os.path.join(Setting.GetCachePath(), config.ChatSavePath))
+            self.cacheDir.setText(Setting.GetCachePath())
+            self.waifu2xDir.setText(os.path.join(Setting.GetCachePath(), config.Waifu2xPath))
 
     def SavePath(self):
         path = self.lineEdit.text()

--- a/src/view/info/book_info_view.py
+++ b/src/view/info/book_info_view.py
@@ -121,8 +121,8 @@ class BookInfoView(QtWidgets.QWidget, Ui_BookInfo, QtTaskBase):
         else:
             self.favoriteButton.setIcon(QIcon(":/png/icon/icon_like_off.png"))
 
-        path = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir), "book/{}".format(self.bookId))
-        waifuPath = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir), "waifu2x/book/{}".format(self.bookId))
+        path = os.path.join(Setting.GetCachePath(), "book/{}".format(self.bookId))
+        waifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/book/{}".format(self.bookId))
         if os.path.isdir(path) or os.path.isdir(waifuPath):
             self.clearButton.setIcon(QIcon(":/png/icon/clear_on.png"))
         else:
@@ -541,18 +541,14 @@ class BookInfoView(QtWidgets.QWidget, Ui_BookInfo, QtTaskBase):
             QtOwner().favoriteView.DelAndFavoritesBack({"st": Status.Ok}, self.bookId)
 
     def ClearCache(self):
-        path = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir),
-                            "book/{}".format(self.bookId))
-        waifuPath = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir),
-                                 "waifu2x/book/{}".format(self.bookId))
+        path = os.path.join(Setting.GetCachePath(), "book/{}".format(self.bookId))
+        waifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/book/{}".format(self.bookId))
         isClear = QMessageBox.information(self, '清除缓存', "是否清除本书所有缓存\n{}\n{}".format(path, waifuPath), QtWidgets.QMessageBox.Yes|QtWidgets.QMessageBox.No)
         if isClear == QtWidgets.QMessageBox.Yes:
             if not Setting.SavePath.value:
                 return
-            path = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir),
-                                "book/{}".format(self.bookId))
-            waifuPath = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir),
-                                     "waifu2x/book/{}".format(self.bookId))
+            path = os.path.join(Setting.GetCachePath(), "book/{}".format(self.bookId))
+            waifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/book/{}".format(self.bookId))
             if os.path.isdir(path):
                 shutil.rmtree(path, True)
             if os.path.isdir(waifuPath):

--- a/src/view/nas/nas_db.py
+++ b/src/view/nas/nas_db.py
@@ -13,7 +13,7 @@ from view.nas.nas_item import NasUploadItem, NasInfoItem
 class NasDb(object):
     def __init__(self):
         self.db = QSqlDatabase.addDatabase("QSQLITE", "nas")
-        path = os.path.join(Setting.GetConfigPath(), "nas.db")
+        path = os.path.join(Setting.GetStatePath(), "nas.db")
         self.db.setDatabaseName(path)
         if not self.db.open():
             Log.Warn(self.db.lastError().text())

--- a/src/view/nas/nas_item.py
+++ b/src/view/nas/nas_item.py
@@ -168,7 +168,7 @@ class NasUploadItem(QtTaskBase):
         if nasInfo.is_waifu2x:
             srcDir = os.path.join(downloadInfo.convertPath, ToolUtil.GetCanSaveName(epsInfo.epsTitle))
 
-        desPath = os.path.join(os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir), "zip"), ToolUtil.GetCanSaveName(downloadInfo.title))
+        desPath = os.path.join(os.path.join(Setting.GetCachePath(), "zip"), ToolUtil.GetCanSaveName(downloadInfo.title))
 
         if self.curPreUpIndex == 0:
             desFile = os.path.join(desPath, "{}.zip".format(ToolUtil.GetCanSaveName(downloadInfo.title)))

--- a/src/view/setting/setting_view.py
+++ b/src/view/setting/setting_view.py
@@ -471,9 +471,9 @@ class SettingView(QtWidgets.QWidget, Ui_SettingNew):
         if not url:
             url = "./"
         self.downloadDir.setText(os.path.join(url, config.SavePathDir))
-        self.chatDir.setText(os.path.join(url, config.ChatSavePath))
-        self.cacheDir.setText(os.path.join(url, config.CachePathDir))
-        self.waifu2xDir.setText(os.path.join(os.path.join(url, config.CachePathDir), config.Waifu2xPath))
+        self.chatDir.setText(os.path.join(Setting.GetCachePath(), config.ChatSavePath))
+        self.cacheDir.setText(Setting.GetCachePath())
+        self.waifu2xDir.setText(os.path.join(Setting.GetCachePath(), config.Waifu2xPath))
 
         self.logLabel.setText(Setting.GetLogPath())
 

--- a/src/view/tool/batch_sr_tool_db.py
+++ b/src/view/tool/batch_sr_tool_db.py
@@ -11,7 +11,7 @@ from tools.log import Log
 class BatchSrToolDb(object):
     def __init__(self):
         self.db = QSqlDatabase.addDatabase("QSQLITE", "batch_sr_tool")
-        path = os.path.join(Setting.GetConfigPath(), "batch_sr_tool.db")
+        path = os.path.join(Setting.GetStatePath(), "batch_sr_tool.db")
         self.db.setDatabaseName(path)
         if not self.db.open():
             Log.Warn(self.db.lastError().text())

--- a/src/view/tool/local_read_db.py
+++ b/src/view/tool/local_read_db.py
@@ -11,7 +11,7 @@ from view.download.download_item import DownloadItem, DownloadEpsItem
 
 class LocalReadDb(object):
     def __init__(self):
-        self.db = sqlite3.connect(os.path.join(Setting.GetConfigPath(), "local_read.db"), check_same_thread=False)
+        self.db = sqlite3.connect(os.path.join(Setting.GetStatePath(), "local_read.db"), check_same_thread=False)
         self.cur = self.db.cursor()
 
         sql = """\

--- a/src/view/user/history_view.py
+++ b/src/view/user/history_view.py
@@ -32,7 +32,7 @@ class HistoryView(QtWidgets.QWidget, Ui_History):
         self.bookList.LoadCallBack = self.LoadNextPage
         self.history = {}
         self.db = QSqlDatabase.addDatabase("QSQLITE", "history")
-        path = os.path.join(Setting.GetConfigPath(), "history.db")
+        path = os.path.join(Setting.GetStatePath(), "history.db")
         self.db.setDatabaseName(path)
         # self.bookList.InstallDel()
 


### PR DESCRIPTION
大佬好，感谢项目，特地献上Linux端遵循[XDG目录](https://wiki.archlinux.org/title/XDG_Base_Directory)的重构，已在NixOS测试完毕。

主要变更如下：
- 删除过时的迁移代码，避免在HOME直接创建点目录
- 按照XDG目录规则组织项目创建文件，修复前端目录展示
- 新增聊天语音缓存子目录，与图片缓存对齐
- 修改仅对Linux端生效，Windows端仍为原逻辑（除语音缓存子目录）

```
~/.config/picacg-qt/                      # XDG_CONFIG_HOME
  └── config.ini

~/.local/share/picacg-qt/                 # XDG_DATA_HOME（SavePath默认值）
  ├── commies/
  └── db/
      └── book.db

~/.cache/picacg-qt/                       # XDG_CACHE_HOME
  ├── book/{bookId}/
  ├── chat/
  │   ├── picture/
  │   └── audio/                          # 聊天语音（新增子目录）
  ├── waifu2x/
  ├── zip/
  └── cache_word

~/.local/state/picacg-qt/                 # XDG_STATE_HOME
  ├── logs/
  ├── convert.db
  ├── download.db
  ├── nas.db
  ├── history.db
  ├── local_read.db
  └── batch_sr_tool.db
```

以上，祝好。