### PR TITLE
fix: fix clear cache button in comic detail

### DIFF
--- a/src/view/info/book_info_view.py
+++ b/src/view/info/book_info_view.py
@@ -1,3 +1,4 @@
+import glob
 import json
 import os
 import shutil
@@ -121,9 +122,9 @@ class BookInfoView(QtWidgets.QWidget, Ui_BookInfo, QtTaskBase):
         else:
             self.favoriteButton.setIcon(QIcon(":/png/icon/icon_like_off.png"))
 
-        path = os.path.join(Setting.GetCachePath(), "book/{}".format(self.bookId))
-        waifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/book/{}".format(self.bookId))
-        if os.path.isdir(path) or os.path.isdir(waifuPath):
+        path = os.path.join(Setting.GetCachePath(), "cover/{}.*".format(self.bookId))
+        waifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/cover/{}.*".format(self.bookId))
+        if glob.glob(path) or glob.glob(waifuPath):
             self.clearButton.setIcon(QIcon(":/png/icon/clear_on.png"))
         else:
             self.clearButton.setIcon(QIcon(":/png/icon/clear_off.png"))
@@ -541,18 +542,18 @@ class BookInfoView(QtWidgets.QWidget, Ui_BookInfo, QtTaskBase):
             QtOwner().favoriteView.DelAndFavoritesBack({"st": Status.Ok}, self.bookId)
 
     def ClearCache(self):
-        path = os.path.join(Setting.GetCachePath(), "book/{}".format(self.bookId))
-        waifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/book/{}".format(self.bookId))
-        isClear = QMessageBox.information(self, '清除缓存', "是否清除本书所有缓存\n{}\n{}".format(path, waifuPath), QtWidgets.QMessageBox.Yes|QtWidgets.QMessageBox.No)
+        displayPath = os.path.join(Setting.GetCachePath(), "cover/{}".format(self.bookId))
+        displayWaifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/cover/{}".format(self.bookId))
+        path = displayPath + ".*"
+        waifuPath = displayWaifuPath + ".*"
+        isClear = QMessageBox.information(self, '清除缓存', "是否清除本书所有缓存\n{}\n{}".format(displayPath, displayWaifuPath), QtWidgets.QMessageBox.Yes|QtWidgets.QMessageBox.No)
         if isClear == QtWidgets.QMessageBox.Yes:
             if not Setting.SavePath.value:
                 return
-            path = os.path.join(Setting.GetCachePath(), "book/{}".format(self.bookId))
-            waifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/book/{}".format(self.bookId))
-            if os.path.isdir(path):
-                shutil.rmtree(path, True)
-            if os.path.isdir(waifuPath):
-                shutil.rmtree(waifuPath, True)
+            for f in glob.glob(path):
+                os.remove(f)
+            for f in glob.glob(waifuPath):
+                os.remove(f)
         self.UpdateFavoriteIcon()
 
 


### PR DESCRIPTION
大佬好。

同步jmcomic-qt的[PR](https://github.com/tonquer/JMComic-qt/pull/217)中的部分修复到picacg-qt项目。

主要修改：
- 修复漫画详情页中清理按钮的匹配逻辑（含目录、文件匹配）

现在缓存中存在封面时，能正常高亮并正确清理对应封面/超分封面。

结果如下：
<img width="1060" height="194" alt="image" src="https://github.com/user-attachments/assets/091333a2-5564-423c-9b9f-cd335bd50499" />
