### PR TITLE
refactor: rewrite transaction handling to fix "database is locked"

### DIFF
--- a/src/server/sql_server.py
+++ b/src/server/sql_server.py
@@ -96,9 +96,10 @@ class SqlServer(Singleton):
         try:
             if sys.platform == "linux":
                 path = os.path.join(Setting.GetDataPath(), bookPath)
-                conn = sqlite3.connect(path)
+                conn = sqlite3.connect(path, timeout=5)
             else:
-                conn = sqlite3.connect(bookPath)
+                conn = sqlite3.connect(bookPath, timeout=5)
+            conn.execute("PRAGMA journal_mode=WAL")
         except Exception as es:
             Log.Error(es)
             from qt_owner import QtOwner

--- a/src/server/sql_server.py
+++ b/src/server/sql_server.py
@@ -132,8 +132,8 @@ class SqlServer(Singleton):
                     TaskSql().taskObj.sqlBack.emit(backId, data2)
                 elif taskType == self.TaskTypeSql:
                     cur = conn.cursor()
-                    cur.execute(data)
-                    cur.execute("COMMIT")
+                    with conn:
+                        cur.execute(data)
                     if backId:
                         data2 = pickle.dumps("")
                         TaskSql().taskObj.sqlBack.emit(backId, data2)
@@ -309,13 +309,13 @@ class SqlServer(Singleton):
         cur = conn.cursor()
 
         addData, tick, version = data
-        timeArray = time.localtime(tick)
-        strTime = "{}-{}-{} {}:{}:{}".format(timeArray.tm_year, timeArray.tm_mon, timeArray.tm_mday, timeArray.tm_hour, timeArray.tm_min, timeArray.tm_sec)
-        sql = "update system set sub_version={}, time='{}' where id='{}'".format(version, strTime, config.DbVersion)
-        cur.execute(sql)
+        with conn:
+            timeArray = time.localtime(tick)
+            strTime = "{}-{}-{} {}:{}:{}".format(timeArray.tm_year, timeArray.tm_mon, timeArray.tm_mday, timeArray.tm_hour, timeArray.tm_min, timeArray.tm_sec)
+            sql = "update system set sub_version={}, time='{}' where id='{}'".format(version, strTime, config.DbVersion)
+            cur.execute(sql)
 
-        for book in addData:
-            try:
+            for book in addData:
                 if not book:
                     continue
                 sql = "replace INTO book(id, title, title2, author, chineseTeam, description, epsCount, pages, finished, likesCount, categories, tags," \
@@ -328,37 +328,26 @@ class SqlServer(Singleton):
                 sql = sql.replace("\0", "")
                 cur.execute(sql)
 
-                try:
-                    for name in book.categories.split(","):
-                        from tools.category import CateGoryMgr
-                        index = CateGoryMgr().categoriseIndex.get(name)
-                        if not index:
-                            continue
-                        sql = "replace INTO category(bookId, category) VALUES ('{0}', {1}); ".format(book.id, index)
-                        sql = sql.replace("\0", "")
-                        cur.execute(sql)
-                except Exception as es:
-                    Log.Error(es)
+                for name in book.categories.split(","):
+                    from tools.category import CateGoryMgr
+                    index = CateGoryMgr().categoriseIndex.get(name)
+                    if not index:
+                        continue
+                    sql = "replace INTO category(bookId, category) VALUES ('{0}', {1}); ".format(book.id, index)
+                    sql = sql.replace("\0", "")
+                    cur.execute(sql)
 
-            except Exception as ex:
-                Log.Error(ex)
-
-        cur.execute("COMMIT")
-        Log.Info("db: update database, len:{}, version:{}, tick:{} ".format(len(addData), tick, version))
+            Log.Info("db: update database, len:{}, version:{}, tick:{} ".format(len(addData), tick, version))
 
     def _UpdateFavorite(self, conn, addData, backId):
         cur = conn.cursor()
-        for bookId, sortId in addData:
-            try:
+        with conn:
+            for bookId, sortId in addData:
                 if not bookId:
                     continue
                 sql = "replace INTO favorite(id, user, sortId) VALUES ('{0}', '{1}', {2});".format(bookId, Setting.UserId.value, sortId)
                 sql = sql.replace("\0", "")
                 cur.execute(sql)
-            except Exception as ex:
-                Log.Error(ex)
-
-        cur.execute("COMMIT")
 
     @staticmethod
     def SearchFavorite(page, sortKey=0, sortId=0, searchText=""):


### PR DESCRIPTION
大佬好。

## 主要问题
- 写路径有显式COMMIT但无ROLLBACK，若SQL执行失败后不回滚事务，文件锁不会释放
- 嵌套try可能会重复上报日志，`_RUN()`的循环内本身最外层的try就有`Log.Error()`

日志如下： 
```
2026-06-27 19:56:26,736 - sql_server.py[line:160] - ERROR: database is locked
Traceback (most recent call last):
  File "/nix/store/cdxjhkr8ixpg8h23q6136041gw0v8lxd-picacg-qt-1.5.4/share/picacg-qt/server/sql_server.py">
    self._UpdateFavorite(conn, data, backId)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/cdxjhkr8ixpg8h23q6136041gw0v8lxd-picacg-qt-1.5.4/share/picacg-qt/server/sql_server.py">
    cur.execute("COMMIT")
    ~~~~~~~~~~~^^^^^^^^^^
sqlite3.OperationalError: database is locked
```

## 核心对策
- 使用`with conn`上下文包裹原始逻辑，自动处理事务
- 设置连接超时并启用WAL，减少数据库锁冲突
- 移除不必要的try-except，交由主循环捕获

以上，祝好。